### PR TITLE
Added new line to default string marshelling in IPC context.

### DIFF
--- a/Effect/Msg.idr
+++ b/Effect/Msg.idr
@@ -314,7 +314,7 @@ fget f = do fpoll f
 
 -- Serialisation commands for `String` types
 instance IPCValue String where
-  toIPCString x   = x
+  toIPCString x   = x ++ "\n"
   fromIPCString x = Just x
 
 -- Generic marshalling commands for data in the IPC context.


### PR DESCRIPTION
Make sure default String marshaling function adds a new line.
